### PR TITLE
自动判断路由是前进还是后退,从而实现对应转场效果

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -130,31 +130,46 @@ const plugin = {
         }
       } : null
     })
-
+	var pathArr=[];//用于存放路由跳转记录
     router.beforeEach((to, from, next) => {
       route = to
       let toDepth = to.path.split('/').filter(v => !!v).length
       let fromDepth = from.path.split('/').filter(v => !!v).length
-
+	
       transitionType = toDepth > fromDepth ? 'forward' : 'back'
+      //第一次进入首页,记录首页路由
+      if(from.path=='/'){
+        pathArr.push(to.path);
+      }
       //深度相同
       if (toDepth === fromDepth) {
-        if (lastPath === to.path && toDepth < fromDepth) {
+        //if (lastPath === to.path && toDepth < fromDepth) {
+        //  transitionType = 'back'
+        //} else {
+        //  transitionType = 'forward'
+        //}
+
+        //队列中无记录则为前进,有则为返回,且清除返回之前的路由记录
+        var index=pathArr.indexOf(to.path);
+        if(index!=-1){
           transitionType = 'back'
-        } else {
+          pathArr.splice(index+1,pathArr.length-index);
+        }else{
+          pathArr.push(to.path);
           transitionType = 'forward'
         }
+		  
         //深度相同时禁用动画
         if (op.disableAtSameDepths)
           transitionType = null
 
         lastPath = from.path
       }
-
       //首次进入无效果
       if (to.path === from.path && to.path === lastPath)
         transitionType = 'first'
-
+		
+console.log(pathArr);
       // 处理map选项
       const enter = Object.keys(op.map).find(key => op.map[key].enter && op.map[key].enter.includes(from.name))
       const leave = Object.keys(op.map).find(key => op.map[key].leave && op.map[key].leave.includes(to.name))

--- a/src/index.js
+++ b/src/index.js
@@ -143,22 +143,15 @@ const plugin = {
       }
       //深度相同
       if (toDepth === fromDepth) {
-        //if (lastPath === to.path && toDepth < fromDepth) {
-        //  transitionType = 'back'
-        //} else {
-        //  transitionType = 'forward'
-        //}
-
         //队列中无记录则为前进,有则为返回,且清除返回之前的路由记录
-        var index=pathArr.indexOf(to.path);
+        var index=pathArr.indexOf(to.path)
         if(index!=-1){
           transitionType = 'back'
-          pathArr.splice(index+1,pathArr.length-index);
+          pathArr.splice(index+1,pathArr.length-index)
         }else{
-          pathArr.push(to.path);
+          pathArr.push(to.path)
           transitionType = 'forward'
         }
-		  
         //深度相同时禁用动画
         if (op.disableAtSameDepths)
           transitionType = null
@@ -169,7 +162,6 @@ const plugin = {
       if (to.path === from.path && to.path === lastPath)
         transitionType = 'first'
 		
-console.log(pathArr);
       // 处理map选项
       const enter = Object.keys(op.map).find(key => op.map[key].enter && op.map[key].enter.includes(from.name))
       const leave = Object.keys(op.map).find(key => op.map[key].leave && op.map[key].leave.includes(to.name))


### PR DESCRIPTION
目前无法自动识别路由是前进还是后退,通过数组队列进行简单的判断,达到了调用router.back或浏览器后退能准确触发后退转场动画.